### PR TITLE
Events can now be sent out of the WifiTester via a local broadcast manager

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -4,5 +4,6 @@
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/edu/rit/se/crashavoidance/views/AvailableServicesActivity.java
+++ b/app/src/main/java/edu/rit/se/crashavoidance/views/AvailableServicesActivity.java
@@ -1,18 +1,37 @@
 package edu.rit.se.crashavoidance.views;
 
 import android.content.Intent;
+import android.net.wifi.p2p.WifiP2pConfig;
+import android.net.wifi.p2p.WifiP2pDevice;
+import android.net.wifi.p2p.WifiP2pManager;
+import android.net.wifi.p2p.nsd.WifiP2pDnsSdServiceRequest;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.widget.ListView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import edu.rit.se.crashavoidance.R;
 import edu.rit.se.crashavoidance.WiFiP2pService;
+import edu.rit.se.crashavoidance.wifi.DnsSdService;
+import edu.rit.se.crashavoidance.wifi.DnsSdTxtRecord;
+import edu.rit.se.crashavoidance.wifi.WifiTester;
 
 public class AvailableServicesActivity extends AppCompatActivity {
+
+    private WifiP2pManager wifiP2pManager;
+    private WifiP2pManager.Channel wifiP2pChannel;
+    private WiFiP2pService wifiService;
+    private WifiTester wifiTester;
+    private WifiTester.Builder builder;
+    private Map<String, DnsSdTxtRecord> dnsSdTxtRecordMap;
+    private Map<String, DnsSdService> dnsSdServiceMap;
+    List<WiFiP2pService> services = new ArrayList<WiFiP2pService>();
+    AvailableServicesListViewAdapter serviceListAdapter;
 
     public void onServiceClick(WiFiP2pService service) {
         //TODO: call actual connection logic.
@@ -30,22 +49,75 @@ public class AvailableServicesActivity extends AppCompatActivity {
         setSupportActionBar(toolbar);
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-
         setServiceList();
+        startDiscoveringServices();
     }
 
     //TODO: There will need to be a way to dynamically add/remove services
     private void setServiceList(){
-        List<WiFiP2pService> services = new ArrayList<WiFiP2pService>();
-        // TODO populate off of service detected
-
-        WiFiP2pService s1 = new WiFiP2pService();
-        s1.instanceName = "instance name";
-        s1.serviceRegistrationType = "registration type";
-
-        services.add(s1);
+        wifiTester = WifiTester.Builder.getInstance().build();
+        wifiP2pManager = wifiTester.getManager();
+        wifiP2pChannel = wifiTester.getChannel();
 
         ListView listView = (ListView) findViewById(R.id.availableServicesList);
-        listView.setAdapter(new AvailableServicesListViewAdapter(this, services));
+        serviceListAdapter = new AvailableServicesListViewAdapter(this, services);
+        listView.setAdapter(serviceListAdapter);
+    }
+
+    // TODO move this to use the one in WifiTester
+    public void startDiscoveringServices() {
+        WifiP2pManager.DnsSdTxtRecordListener txtRecordListener = new WifiP2pManager.DnsSdTxtRecordListener() {
+            @Override
+            public void onDnsSdTxtRecordAvailable(String fullDomainName, Map<String, String> txtRecordMap, WifiP2pDevice srcDevice) {
+//                dnsSdTxtRecordMap.put(srcDevice.deviceAddress, new DnsSdTxtRecord(fullDomainName, txtRecordMap, srcDevice));
+            }
+        };
+
+        WifiP2pManager.DnsSdServiceResponseListener serviceResponseListener = new WifiP2pManager.DnsSdServiceResponseListener() {
+            @Override
+            public void onDnsSdServiceAvailable(String instanceName, String registrationType, WifiP2pDevice srcDevice) {
+                Log.d("AvailableServices", "Service available");
+//                dnsSdServiceMap.put(srcDevice.deviceAddress, new DnsSdService(instanceName, registrationType, srcDevice));
+                // Add service to service list and let the adapter know the list has changed
+                // TODO not sure if we are still using this service object
+                WiFiP2pService service = new WiFiP2pService();
+                service.device = srcDevice;
+                service.instanceName = instanceName;
+                service.serviceRegistrationType = registrationType;
+                services.add(service);
+                for (WiFiP2pService loopService : services) {
+                    Log.d("AvailbleServices", "Service discovered: " + loopService.instanceName);
+                }
+                serviceListAdapter.notifyDataSetChanged();
+            }
+            //TODO: Maybe an observer pattern or something to indicate a change
+
+        };
+
+        wifiP2pManager.setDnsSdResponseListeners(wifiP2pChannel, serviceResponseListener, txtRecordListener);
+        WifiP2pDnsSdServiceRequest serviceRequest = WifiP2pDnsSdServiceRequest.newInstance();
+        wifiP2pManager.addServiceRequest(wifiP2pChannel, serviceRequest,
+                new WifiP2pManager.ActionListener() {
+
+                    @Override
+                    public void onSuccess() {
+                    }
+
+                    @Override
+                    public void onFailure(int errorCode) {
+                    }
+                });
+        wifiP2pManager.discoverServices(wifiP2pChannel, new WifiP2pManager.ActionListener() {
+
+            @Override
+            public void onSuccess() {
+            }
+
+            @Override
+            public void onFailure(int arg0) {
+
+            }
+        });
+
     }
 }

--- a/app/src/main/java/edu/rit/se/crashavoidance/views/AvailableServicesListViewAdapter.java
+++ b/app/src/main/java/edu/rit/se/crashavoidance/views/AvailableServicesListViewAdapter.java
@@ -51,8 +51,11 @@ public class AvailableServicesListViewAdapter extends BaseAdapter {
         }
 
         TextView instanceName = (TextView) convertView.findViewById(R.id.instanceName);
+        TextView deviceName = (TextView) convertView.findViewById(R.id.deviceName);
         //TODO: This will need updates once real devices are in use
         instanceName.setText(service.instanceName);
+
+        deviceName.setText(service.device.deviceName);
 
         convertView.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/edu/rit/se/crashavoidance/views/initActivity.java
+++ b/app/src/main/java/edu/rit/se/crashavoidance/views/initActivity.java
@@ -6,6 +6,7 @@ import android.net.wifi.WifiManager;
 import android.net.wifi.p2p.WifiP2pManager;
 import android.net.wifi.p2p.nsd.WifiP2pDnsSdServiceInfo;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
@@ -19,6 +20,7 @@ import java.util.Map;
 
 import edu.rit.se.crashavoidance.R;
 import edu.rit.se.crashavoidance.WiFiDirectBroadcastReceiver;
+import edu.rit.se.crashavoidance.wifi.WifiTester;
 
 public class initActivity extends AppCompatActivity {
 
@@ -47,6 +49,8 @@ public class initActivity extends AppCompatActivity {
     // Log
     private String log;
     public final static String EXTRA_LOG = "edu.rit.se.crashavoidance.LOG";
+    private WifiTester wifiTester;
+    private WifiTester.Builder builder;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,6 +66,7 @@ public class initActivity extends AppCompatActivity {
 
         // Wi-Fi Service Manager
         wifiManager = (WifiManager) this.getSystemService(Context.WIFI_SERVICE);
+        wifiTester = WifiTester.Builder.getInstance().build();
 
         // Initialize Buttons
         toggleWifiButton = (Button) findViewById(R.id.toggleWifiButton);
@@ -195,6 +200,8 @@ public class initActivity extends AppCompatActivity {
             // Wi-Fi is enabled, continue registration
             wifiP2pManager = (WifiP2pManager) getSystemService(WIFI_P2P_SERVICE);
             wifiP2pChannel = wifiP2pManager.initialize(this, getMainLooper(), null);
+            wifiTester.setManager(wifiP2pManager);
+            wifiTester.setChannel(wifiP2pChannel);
             wifiDirectRegistrationButton.setText(getString(R.string.action_unregister_wifi_direct));
             displayToast(getString(R.string.status_wifi_direct_initialized));
         } else {

--- a/app/src/main/java/edu/rit/se/crashavoidance/wifi/WifiTester.java
+++ b/app/src/main/java/edu/rit/se/crashavoidance/wifi/WifiTester.java
@@ -26,8 +26,9 @@ public class WifiTester extends BroadcastReceiver {
     private LocalBroadcastManager localBroadcastManager;
 
     //Variables created in constructor
-    WifiP2pManager.Channel channel;
-    WifiP2pManager manager;
+    private WifiP2pManager.Channel channel;
+    private WifiP2pManager manager;
+
 
     private WifiTester(Builder builder) {
         this.serviceName = builder.serviceName;
@@ -118,14 +119,34 @@ public class WifiTester extends BroadcastReceiver {
         }
     }
 
-    public class Builder {
+
+
+    public WifiP2pManager.Channel getChannel() {
+        return channel;
+    }
+
+    public void setChannel(WifiP2pManager.Channel channel) {
+        this.channel = channel;
+    }
+
+    public WifiP2pManager getManager() {
+        return manager;
+    }
+
+    public void setManager(WifiP2pManager manager) {
+        this.manager = manager;
+    }
+
+    public static class Builder {
         protected String serviceName = "testService";
         protected ServiceType serviceType = ServiceType.PRESENCE_TCP;
         protected Map<String, String> record = new HashMap<>();
         protected int listenPort = 4545;
         protected Context context;
+        private WifiTester wifiInstance;
+        private static Builder builderInstance;
 
-        public Builder() {}
+        private Builder() {}
 
         public Builder setServiceName(String serviceName) {
             this.serviceName = serviceName;
@@ -146,7 +167,18 @@ public class WifiTester extends BroadcastReceiver {
 
         public WifiTester build(Context context) {
             this.context = context;
-            return new WifiTester(this);
+
+            if (wifiInstance == null){
+                wifiInstance = new WifiTester(this);
+            }
+            return wifiInstance;
+        }
+
+        public static Builder getInstance(){
+            if (builderInstance == null){
+                builderInstance = new Builder();
+            }
+            return builderInstance;
         }
     }
 

--- a/app/src/main/res/layout/group_item.xml
+++ b/app/src/main/res/layout/group_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
+    android:layout_width="fill_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal">
     <TextView

--- a/app/src/main/res/layout/group_message_view.xml
+++ b/app/src/main/res/layout/group_message_view.xml
@@ -2,39 +2,40 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
-    android:layout_width="match_parent"
+    android:layout_width="fill_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:orientation="horizontal">
-        <EditText
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:hint="Input message"
-            android:id="@+id/messageView"
-            android:layout_toLeftOf="@+id/sendAllButton"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true" />
-
-        <Button
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Send to all"
-            android:id="@+id/sendAllButton"
-            android:layout_alignBottom="@+id/messageView"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true" />
-        </LinearLayout>
+            android:layout_gravity="center_horizontal"
+            android:orientation="horizontal"
+            android:gravity="fill">
+            <EditText
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:hint="Input message"
+                android:id="@+id/messageView"
+                android:layout_toLeftOf="@+id/sendAllButton"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true" />
+
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Send to all"
+                android:id="@+id/sendAllButton"
+                android:layout_alignBottom="@+id/messageView"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true" />
+            </LinearLayout>
 
 
-        <ListView
-            tools:listitem="@layout/group_item"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/peerListView"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true" />
+            <ListView
+                tools:listitem="@layout/group_item"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/peerListView"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true" />
 </LinearLayout>


### PR DESCRIPTION
Basic idea based on [this stackoverflow answer](http://stackoverflow.com/a/8875292/2354849)

This allows activities to register and unregister broadcast receivers to listen to events from the WifiTester. The local broadcast manager ensures the broadcast is contained within the app.
