### PR TITLE
Starts to address issue #135 - Handle device disconnecting

### DIFF
--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/CommunicationManager.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/CommunicationManager.java
@@ -49,8 +49,9 @@ public class CommunicationManager implements Runnable {
                             bytes, -1, buffer.clone()).sendToTarget();
                     buffer = new byte[1024];
                 } catch (IOException e) {
-                    Log.e(TAG, "Communication disconnected", e);
-                    // TODO: Handle disconnect
+                    // Sends a message to WifiDirectHandler to handle the disconnect
+                    handler.obtainMessage(WifiDirectHandler.COMMUNICATION_DISCONNECTED, this).sendToTarget();
+                    Log.i(TAG, "Communication disconnected");
                 }
             }
         } catch (IOException e) {

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -62,6 +62,7 @@ public class WifiDirectHandler extends NonStopIntentService implements
     private CommunicationManager communicationManager = null;
     public static final int MESSAGE_READ = 0x400 + 1;
     public static final int MY_HANDLE = 0x400 + 2;
+    public static final int COMMUNICATION_DISCONNECTED = 0x400 + 3;
     public static final int SERVER_PORT = 4545;
 
     private boolean continueDiscovering = false;
@@ -838,6 +839,11 @@ public class WifiDirectHandler extends NonStopIntentService implements
             case MY_HANDLE:
                 Object messageObject = msg.obj;
                 communicationManager = (CommunicationManager) messageObject;
+                break;
+            case COMMUNICATION_DISCONNECTED:
+                Log.i(TAG, "Handling communication disconnect");
+                // TODO: handle disconnect
+
         }
         return true;
     }

--- a/wifibuddy/wifibuddy.iml
+++ b/wifibuddy/wifibuddy.iml
@@ -65,14 +65,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -81,6 +73,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />


### PR DESCRIPTION
Starts to address issue #135 - handle device disconnecting

CommunicationReceiver sends a message to WifiDirectHandler when communication disconnects. WifiDirectHandler listens for that message and can handle the disconnect. I haven't handled it yet but I want to make sure the log line prints when integrated with wifi-direct-tester.