### PR TITLE
Added a gradle step to build a jar

### DIFF
--- a/wifibuddy/build.gradle
+++ b/wifibuddy/build.gradle
@@ -23,3 +23,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.4.0'
 }
+
+task jar(type: Jar, dependsOn: 'assembleRelease') {
+    from fileTree(dir: 'build/intermediates/classes/release')
+}


### PR DESCRIPTION
just run the `jar` task to build a jar. This way you can import the jar in another project

@brendankirby 