### PR TITLE
Enhancements

### DIFF
--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -437,8 +437,10 @@ public class WifiDirectHandler extends NonStopIntentService implements
         dnsSdServiceMap = null;
         dnsSdTxtRecordMap = null;
         // Cancel all discover tasks that may be in progress
-        for (ServiceDiscoveryTask serviceDiscoveryTask : serviceDiscoveryTasks) {
-            serviceDiscoveryTask.cancel();
+        if (!serviceDiscoveryTasks.isEmpty()) {
+            for (ServiceDiscoveryTask serviceDiscoveryTask : serviceDiscoveryTasks) {
+                serviceDiscoveryTask.cancel();
+            }
         }
         serviceDiscoveryTasks = null;
         continuouslyDiscovering = false;

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -436,12 +436,12 @@ public class WifiDirectHandler extends NonStopIntentService implements
     public void stopServiceDiscovery() {
         dnsSdServiceMap = null;
         dnsSdTxtRecordMap = null;
-        serviceDiscoveryTasks = null;
         continuouslyDiscovering = false;
         // Cancel all discover tasks that may be in progress
         for (ServiceDiscoveryTask serviceDiscoveryTask : serviceDiscoveryTasks) {
             serviceDiscoveryTask.cancel();
         }
+        serviceDiscoveryTasks = null;
         Log.i(TAG, "Service discovery stopped");
         clearServiceDiscoveryRequests();
     }

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -271,7 +271,7 @@ public class WifiDirectHandler extends NonStopIntentService implements
         super.onDestroy();
         removeGroup();
         removePersistentGroups();
-        clearServiceDiscoveryRequests();
+        stopServiceDiscovery();
         removeService();
         unregisterP2pReceiver();
         unregisterP2p();
@@ -433,6 +433,14 @@ public class WifiDirectHandler extends NonStopIntentService implements
         }
     }
 
+    public void stopServiceDiscovery() {
+        dnsSdServiceMap = null;
+        dnsSdTxtRecordMap = null;
+        serviceDiscoveryTasks = null;
+        continuouslyDiscovering = false;
+        clearServiceDiscoveryRequests();
+    }
+
     /**
      * Submits a new task to initiate service discovery after the discovery
      * timeout period has expired
@@ -530,7 +538,7 @@ public class WifiDirectHandler extends NonStopIntentService implements
                 @Override
                 public void onSuccess() {
                     serviceRequest = null;
-                    Log.i(TAG, "Service discovery request removed");
+                    Log.i(TAG, "Service discovery requests cleared");
                 }
 
                 @Override
@@ -538,7 +546,6 @@ public class WifiDirectHandler extends NonStopIntentService implements
                     Log.e(TAG, "Failure clearing service discovery requests: " + FailureReason.fromInteger(reason).toString());
                 }
             });
-            serviceRequest = null;
         }
     }
 

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -107,8 +107,6 @@ public class WifiDirectHandler extends NonStopIntentService implements
         // if Wi-Fi is enabled
         if (wifiManager.isWifiEnabled()) {
             Log.i(TAG, "Wi-Fi enabled on load");
-            registerP2p();
-            registerP2pReceiver();
         } else {
             Log.i(TAG, "Wi-Fi disabled on load");
         }

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -434,18 +434,18 @@ public class WifiDirectHandler extends NonStopIntentService implements
     }
 
     public void stopServiceDiscovery() {
-        dnsSdServiceMap = null;
-        dnsSdTxtRecordMap = null;
-        // Cancel all discover tasks that may be in progress
-        if (!serviceDiscoveryTasks.isEmpty()) {
+        if (continuouslyDiscovering) {
+            dnsSdServiceMap = null;
+            dnsSdTxtRecordMap = null;
+            // Cancel all discover tasks that may be in progress
             for (ServiceDiscoveryTask serviceDiscoveryTask : serviceDiscoveryTasks) {
                 serviceDiscoveryTask.cancel();
             }
+            serviceDiscoveryTasks = null;
+            continuouslyDiscovering = false;
+            Log.i(TAG, "Service discovery stopped");
+            clearServiceDiscoveryRequests();
         }
-        serviceDiscoveryTasks = null;
-        continuouslyDiscovering = false;
-        Log.i(TAG, "Service discovery stopped");
-        clearServiceDiscoveryRequests();
     }
 
     /**

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -436,12 +436,12 @@ public class WifiDirectHandler extends NonStopIntentService implements
     public void stopServiceDiscovery() {
         dnsSdServiceMap = null;
         dnsSdTxtRecordMap = null;
-        continuouslyDiscovering = false;
         // Cancel all discover tasks that may be in progress
         for (ServiceDiscoveryTask serviceDiscoveryTask : serviceDiscoveryTasks) {
             serviceDiscoveryTask.cancel();
         }
         serviceDiscoveryTasks = null;
+        continuouslyDiscovering = false;
         Log.i(TAG, "Service discovery stopped");
         clearServiceDiscoveryRequests();
     }

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -103,8 +103,6 @@ public class WifiDirectHandler extends NonStopIntentService implements
         wifiManager = (WifiManager) getSystemService(WIFI_SERVICE);
         registerWifiReceiver();
 
-        // Registers the app with the P2P framework and registers the P2P BroadcastReceiver
-        // if Wi-Fi is enabled
         if (wifiManager.isWifiEnabled()) {
             Log.i(TAG, "Wi-Fi enabled on load");
         } else {
@@ -191,6 +189,13 @@ public class WifiDirectHandler extends NonStopIntentService implements
         }
     }
 
+    public void unregisterWifi() {
+        if (wifiManager != null) {
+            wifiManager = null;
+            Log.i(TAG, "Wi-Fi manager unregistered");
+        }
+    }
+
     /**
      * The requested connection info is available
      * @param p2pInfo Wi-Fi P2P connection info
@@ -271,6 +276,7 @@ public class WifiDirectHandler extends NonStopIntentService implements
         unregisterP2pReceiver();
         unregisterP2p();
         unregisterWifiReceiver();
+        unregisterWifi();
         Log.i(TAG, "Wifi Handler service destroyed");
     }
 


### PR DESCRIPTION
- Removes redundant p2p and p2p receiver registration 
- Unregisters wifimanager onDestroy
- Stops service discovery when wifiDirectHandler is destroyed
- Fixes an issue where app would crash when paused for two minutes - #163 
- Fixes an issue where IntentReceiver leaked onOnpause - #162 
- Some renaming, refactoring, logging