### PR TITLE
Scans for available Wi-Fi networks on startup

### DIFF
--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -83,6 +83,7 @@ public class WifiDirectHandler extends NonStopIntentService implements
 
     private WifiP2pDevice thisDevice;
     private WifiP2pGroup wifiP2pGroup;
+    private List<ScanResult> wifiScanResults;
 
     /** Constructor **/
     public WifiDirectHandler() {
@@ -191,6 +192,7 @@ public class WifiDirectHandler extends NonStopIntentService implements
 
     public void unregisterWifiReceiver() {
         if (wifiBroadcastReceiver != null) {
+            wifiBroadcastReceiver.abortBroadcast();
             unregisterReceiver(wifiBroadcastReceiver);
             wifiBroadcastReceiver = null;
             Log.i(TAG, "Wi-Fi BroadcastReceiver unregistered");
@@ -695,11 +697,13 @@ public class WifiDirectHandler extends NonStopIntentService implements
 
     private void handleScanResultsAvailable(Intent intent) {
         Log.i(TAG, "Wi-Fi scan results available");
-        List<ScanResult> wifiScanResults = wifiManager.getScanResults();
+        wifiScanResults = wifiManager.getScanResults();
+        Log.i(TAG, "There are " + wifiScanResults.size() + " available networks");
         for (ScanResult wifiScanResult : wifiScanResults) {
-            Log.i(TAG, wifiScanResult.BSSID);
             Log.i(TAG, wifiScanResult.SSID);
         }
+        unregisterWifiReceiver();
+        registerWifiReceiver();
     }
 
     /**

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.NetworkInfo;
+import android.net.wifi.ScanResult;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
 import android.net.wifi.WpsInfo;
@@ -104,6 +105,9 @@ public class WifiDirectHandler extends NonStopIntentService implements
         wifiManager = (WifiManager) getSystemService(WIFI_SERVICE);
         registerWifiReceiver();
 
+        // Scans for available Wi-Fi networks
+        wifiManager.startScan();
+
         if (wifiManager.isWifiEnabled()) {
             Log.i(TAG, "Wi-Fi enabled on load");
         } else {
@@ -180,6 +184,7 @@ public class WifiDirectHandler extends NonStopIntentService implements
 
         // Indicates that Wi-Fi has been enabled, disabled, enabling, disabling, or unknown
         intentFilter.addAction(WifiManager.WIFI_STATE_CHANGED_ACTION);
+        intentFilter.addAction(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION);
         registerReceiver(wifiBroadcastReceiver, intentFilter);
         Log.i(TAG, "Wi-Fi BroadcastReceiver registered");
     }
@@ -665,6 +670,8 @@ public class WifiDirectHandler extends NonStopIntentService implements
             handleThisDeviceChanged(intent);
         } else if (WifiManager.WIFI_STATE_CHANGED_ACTION.equals(action)) {
             handleWifiStateChanged(intent);
+        } else if (WifiManager.SCAN_RESULTS_AVAILABLE_ACTION.equals(action)) {
+            handleScanResultsAvailable(intent);
         }
     }
 
@@ -684,6 +691,14 @@ public class WifiDirectHandler extends NonStopIntentService implements
             unregisterP2p();
         }
         localBroadcastManager.sendBroadcast(new Intent(Action.WIFI_STATE_CHANGED));
+    }
+
+    private void handleScanResultsAvailable(Intent intent) {
+        Log.i(TAG, "Wi-Fi scan results available");
+        List<ScanResult> scanResults = wifiManager.getScanResults();
+        for (ScanResult scanResult : scanResults) {
+            Log.i(TAG, scanResult.toString());
+        }
     }
 
     /**

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -192,7 +192,6 @@ public class WifiDirectHandler extends NonStopIntentService implements
 
     public void unregisterWifiReceiver() {
         if (wifiBroadcastReceiver != null) {
-            wifiBroadcastReceiver.abortBroadcast();
             unregisterReceiver(wifiBroadcastReceiver);
             wifiBroadcastReceiver = null;
             Log.i(TAG, "Wi-Fi BroadcastReceiver unregistered");
@@ -702,8 +701,6 @@ public class WifiDirectHandler extends NonStopIntentService implements
         for (ScanResult wifiScanResult : wifiScanResults) {
             Log.i(TAG, wifiScanResult.SSID);
         }
-        unregisterWifiReceiver();
-        registerWifiReceiver();
     }
 
     /**

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -999,4 +999,8 @@ public class WifiDirectHandler extends NonStopIntentService implements
     public WifiP2pServiceInfo getWifiP2pServiceInfo() {
         return this.wifiP2pServiceInfo;
     }
+
+    public List<ScanResult> getWifiScanResults() {
+        return wifiScanResults;
+    }
 }

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -695,9 +695,10 @@ public class WifiDirectHandler extends NonStopIntentService implements
 
     private void handleScanResultsAvailable(Intent intent) {
         Log.i(TAG, "Wi-Fi scan results available");
-        List<ScanResult> scanResults = wifiManager.getScanResults();
-        for (ScanResult scanResult : scanResults) {
-            Log.i(TAG, scanResult.toString());
+        List<ScanResult> wifiScanResults = wifiManager.getScanResults();
+        for (ScanResult wifiScanResult : wifiScanResults) {
+            Log.i(TAG, wifiScanResult.BSSID);
+            Log.i(TAG, wifiScanResult.SSID);
         }
     }
 

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -701,6 +701,8 @@ public class WifiDirectHandler extends NonStopIntentService implements
         for (ScanResult wifiScanResult : wifiScanResults) {
             Log.i(TAG, wifiScanResult.SSID);
         }
+
+        // Unregister the Wi-Fi receiver and register it again without the SCAN_RESULTS action
         unregisterWifiReceiver();
         wifiBroadcastReceiver = new WifiBroadcastReceiver();
         IntentFilter intentFilter = new IntentFilter();

--- a/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
+++ b/wifibuddy/src/main/java/edu/rit/se/wifibuddy/WifiDirectHandler.java
@@ -697,10 +697,18 @@ public class WifiDirectHandler extends NonStopIntentService implements
     private void handleScanResultsAvailable(Intent intent) {
         Log.i(TAG, "Wi-Fi scan results available");
         wifiScanResults = wifiManager.getScanResults();
-        Log.i(TAG, "There are " + wifiScanResults.size() + " available networks");
+        Log.i(TAG, "There are " + (wifiScanResults.size() - 1) + " available networks");
         for (ScanResult wifiScanResult : wifiScanResults) {
             Log.i(TAG, wifiScanResult.SSID);
         }
+        unregisterWifiReceiver();
+        wifiBroadcastReceiver = new WifiBroadcastReceiver();
+        IntentFilter intentFilter = new IntentFilter();
+
+        // Indicates that Wi-Fi has been enabled, disabled, enabling, disabling, or unknown
+        intentFilter.addAction(WifiManager.WIFI_STATE_CHANGED_ACTION);
+        registerReceiver(wifiBroadcastReceiver, intentFilter);
+        Log.i(TAG, "Wi-Fi BroadcastReceiver registered");
     }
 
     /**


### PR DESCRIPTION
There is a public method getWifiScanResults() that returns a list of the networks that were available on startup. 

Good to merge, will leave open for a bit for visibility. 