### PR TITLE
Add service to AndroidManifest.xml

### DIFF
--- a/wifibuddy/src/main/AndroidManifest.xml
+++ b/wifibuddy/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <application android:allowBackup="true" android:label="@string/app_name"
         android:supportsRtl="true">
 
+        <service android:name=".WifiDirectHandler"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
This should be added to AndroidManifest.xml in the Android library: otherwise when it's used as a library starting the service will fail unless the developer adds it to their individual app manifest.